### PR TITLE
Adapt METAR parsing to vatiris (and upstream) API changes

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -126,7 +126,7 @@ import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { useTopdownStore } from '@/stores/topdownStore.js'
 import StripBay from '@/components/StripBay.vue'
 import { AERODROMES } from '@/data/swedenAerodromes.js'
-import { POSITIONS } from '/home/erik/topdowntool/src/data/swedenPositions.js'
+import { POSITIONS } from '@/data/swedenPositions.js'
 import changelogMd from '../CHANGELOG.md?raw'
 import ChangelogModal from '@/components/ChangelogModal.vue'
 

--- a/src/stores/topdownStore.js
+++ b/src/stores/topdownStore.js
@@ -177,6 +177,7 @@ export const useTopdownStore = defineStore('topdown', {
           lines.forEach((line) => {
             // e.g. "ESGG 301320Z 18005KT 2400..."
             if (!line) return
+            line = line.replace(/^METAR\s*(AMD|COR)?\s*/, "")
             const maybeIcao = line.substring(0, 4).toUpperCase()
             if (!/^[A-Z0-9]{4}$/i.test(maybeIcao)) {
               console.warn('Skipping line:', line)


### PR DESCRIPTION
Quick fix for changes in METAR API (the vatsim API changed unexpectedly, causing a [similar change](https://github.com/minsulander/vatiris/commit/16a832945d483c56953b9861fe2412514c42f903) in VatIRIS).